### PR TITLE
override intputstream /outputstream read and write for byte buffers

### DIFF
--- a/netty-servlet-bridge/src/main/java/net/javaforge/netty/servlet/bridge/impl/ServletInputStreamImpl.java
+++ b/netty-servlet-bridge/src/main/java/net/javaforge/netty/servlet/bridge/impl/ServletInputStreamImpl.java
@@ -38,4 +38,14 @@ public class ServletInputStreamImpl extends ServletInputStream {
         return this.in.read();
     }
 
+    @Override
+    public int read(byte[] buf) throws IOException {
+        return this.in.read(buf);
+    }
+
+    @Override
+    public int read(byte[] buf, int offset, int len) throws IOException {
+        return this.in.read(buf,offset,len);
+    }
+
 }

--- a/netty-servlet-bridge/src/main/java/net/javaforge/netty/servlet/bridge/impl/ServletOutputStreamImpl.java
+++ b/netty-servlet-bridge/src/main/java/net/javaforge/netty/servlet/bridge/impl/ServletOutputStreamImpl.java
@@ -42,6 +42,16 @@ public class ServletOutputStreamImpl extends ServletOutputStream {
     }
 
     @Override
+    public void write(byte[] b) throws IOException {
+        this.out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int offset, int len) throws IOException {
+        this.out.write(b,offset,len);
+    }
+
+    @Override
     public void flush() throws IOException {
         this.response.setContent(out.buffer());
         this.flushed = true;


### PR DESCRIPTION
it is going to be faster since it won't hammer read(int) and write(int) as much
