### PR TITLE
Fix for Apache WINK services JAX-RS implementation

### DIFF
--- a/netty-servlet-bridge/src/main/java/net/javaforge/netty/servlet/bridge/impl/HttpServletResponseImpl.java
+++ b/netty-servlet-bridge/src/main/java/net/javaforge/netty/servlet/bridge/impl/HttpServletResponseImpl.java
@@ -1,24 +1,25 @@
 /*
- * Copyright 2013 by Maxim Kalina
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+* Copyright 2013 by Maxim Kalina
+*
+*    Licensed under the Apache License, Version 2.0 (the "License");
+*    you may not use this file except in compliance with the License.
+*    You may obtain a copy of the License at
+*
+*        http://www.apache.org/licenses/LICENSE-2.0
+*
+*    Unless required by applicable law or agreed to in writing, software
+*    distributed under the License is distributed on an "AS IS" BASIS,
+*    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*    See the License for the specific language governing permissions and
+*    limitations under the License.
+*/
 
 package net.javaforge.netty.servlet.bridge.impl;
 
 import net.javaforge.netty.servlet.bridge.ServletBridgeRuntimeException;
 import org.jboss.netty.handler.codec.http.CookieEncoder;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpHeaders.Names;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
@@ -35,14 +36,11 @@ import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.LOCATION;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.SET_COOKIE;
 
 public class HttpServletResponseImpl implements HttpServletResponse {
-
     private HttpResponse originalResponse;
-
     private ServletOutputStreamImpl outputStream;
-
     private PrintWriterImpl writer;
-
     private boolean responseCommited = false;
+    private Locale locale = null;
 
     public HttpServletResponseImpl(HttpResponse response) {
         this.originalResponse = response;
@@ -136,6 +134,12 @@ public class HttpServletResponseImpl implements HttpServletResponse {
     }
 
     @Override
+    public String getContentType() {
+        return HttpHeaders.getHeader(this.originalResponse,
+                HttpHeaders.Names.CONTENT_TYPE);
+    }
+
+    @Override
     public void setContentType(String type) {
         HttpHeaders.setHeader(this.originalResponse,
                 HttpHeaders.Names.CONTENT_TYPE, type);
@@ -210,34 +214,23 @@ public class HttpServletResponseImpl implements HttpServletResponse {
 
     @Override
     public String getCharacterEncoding() {
-        throw new IllegalStateException(
-                "Method 'getCharacterEncoding' not yet implemented!");
-    }
-
-    @Override
-    public String getContentType() {
-        throw new IllegalStateException(
-                "Method 'getContentType' not yet implemented!");
-    }
-
-    @Override
-    public Locale getLocale() {
-        throw new IllegalStateException(
-                "Method 'getLocale' not yet implemented!");
+        return HttpHeaders.getHeader(this.originalResponse,
+                Names.CONTENT_ENCODING);
     }
 
     @Override
     public void setCharacterEncoding(String charset) {
-        throw new IllegalStateException(
-                "Method 'setCharacterEncoding' not yet implemented!");
+        HttpHeaders.setHeader(this.originalResponse,
+                Names.CONTENT_ENCODING, charset);
+    }
 
+    @Override
+    public Locale getLocale() {
+        return locale;
     }
 
     @Override
     public void setLocale(Locale loc) {
-        throw new IllegalStateException(
-                "Method 'setLocale' not yet implemented!");
-
+        this.locale = loc;
     }
-
 }


### PR DESCRIPTION
I successfully used the Netty servlet bridge with the Apache Wink JAX-RS implementation. Works great and is really light-weight.
There were a couple of exceptions because of not implemented exceptions in this class. I added an implementation - didn't spend a lot of time looking at these methods but tried to be consistent with the other method implementations. 
